### PR TITLE
Disable analytics in container deployments

### DIFF
--- a/packages/api/server/ws.mts
+++ b/packages/api/server/ws.mts
@@ -65,6 +65,8 @@ import { normalizeDiagnostic } from '../tsserver/utils.mjs';
 import { removeCodeCellFromDisk } from '../srcbook/index.mjs';
 import { register as registerAppChannel } from './channels/app.mjs';
 
+const ANALYTICS_DISABLED = (process.env.SRCBOOK_DISABLE_ANALYTICS || '').toLowerCase() === 'true';
+
 type SessionsContextType = MessageContextType<'sessionId'>;
 
 const wss = new WebSocketServer();
@@ -120,7 +122,7 @@ async function cellExec(payload: CellExecPayloadType, context: SessionsContextTy
   }
 
   // Consider removing sessionId and cellId if cardinality increases costs too much
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user ran a cell',
     properties: {
       language: cell.language,
@@ -234,7 +236,7 @@ async function depsInstall(payload: DepsInstallPayloadType, context: SessionsCon
   cell.status = 'running';
   wss.broadcast(`session:${session.id}`, 'cell:updated', { cell });
 
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user installed dependencies',
     properties: {
       sessionId: session.id,
@@ -310,7 +312,7 @@ async function cellStop(payload: CellStopPayloadType, context: SessionsContextTy
     return;
   }
 
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user stopped cell execution',
     properties: {
       sessionId: session.id,
@@ -394,7 +396,7 @@ async function cellGenerate(payload: AiGenerateCellPayloadType, context: Session
   const session = await findSession(context.params.sessionId);
   const cell = session.cells.find((cell) => cell.id === payload.cellId) as CodeCellType;
 
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user edited a cell with AI',
     properties: {
       language: cell.language,
@@ -508,7 +510,7 @@ async function cellRename(payload: CellRenamePayloadType, context: SessionsConte
     );
   }
 
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user renamed cell',
     properties: {
       sessionId: session.id,
@@ -575,7 +577,7 @@ async function cellDelete(payload: CellDeletePayloadType, context: SessionsConte
     );
   }
 
-  posthog.capture({
+  if (!ANALYTICS_DISABLED) posthog.capture({
     event: 'user deleted cell',
     properties: { cellType: cell.type },
   });
@@ -711,7 +713,7 @@ async function tsconfigUpdate(payload: TsConfigUpdatePayloadType, context: Sessi
     throw new Error(`No session exists for session '${context.params.sessionId}'`);
   }
 
-  posthog.capture({ event: 'user updated tsconfig' });
+  if (!ANALYTICS_DISABLED) posthog.capture({ event: 'user updated tsconfig' });
 
   const updatedSession = await updateSession(session, { 'tsconfig.json': payload.source });
 

--- a/srcbook/src/server.mts
+++ b/srcbook/src/server.mts
@@ -16,6 +16,8 @@ import { wss, app, posthog } from '@srcbook/api';
 import chalk from 'chalk';
 import { pathTo, getPackageJson } from './utils.mjs';
 
+const ANALYTICS_DISABLED = (process.env.SRCBOOK_DISABLE_ANALYTICS || '').toLowerCase() === 'true';
+
 function clearScreen() {
   const repeatCount = process.stdout.rows - 2;
   const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : '';
@@ -49,7 +51,7 @@ console.log(chalk.green('Initialization complete'));
 const port = Number(process.env.PORT ?? 2150);
 const url = `http://localhost:${port}`;
 
-posthog.capture({ event: 'user started Srcbook application' });
+if (!ANALYTICS_DISABLED) posthog.capture({ event: 'user started Srcbook application' });
 
 const { name, version } = getPackageJson();
 


### PR DESCRIPTION
Disable PostHog analytics capture calls when `SRCBOOK_DISABLE_ANALYTICS` is set to prevent unnecessary network calls in private environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-14501594-6751-4b3c-8375-deb7d9584197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14501594-6751-4b3c-8375-deb7d9584197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

