### PR TITLE
Expose rest api for cell execution

### DIFF
--- a/packages/api/server/executions.mts
+++ b/packages/api/server/executions.mts
@@ -1,0 +1,74 @@
+import type { CodeCellType } from '@srcbook/shared';
+import { randomid } from '@srcbook/shared';
+
+export type ExecutionOutput = { type: 'stdout' | 'stderr'; data: string };
+
+export type ExecutionRecord = {
+  id: string;
+  sessionId: string;
+  cellId: string;
+  status: 'running' | 'complete' | 'failed';
+  startedAt: number;
+  completedAt?: number;
+  exitCode?: number | null;
+  outputs: ExecutionOutput[];
+};
+
+export type ExecutionListener = (event: { type: 'output' | 'status'; data: any }) => void;
+
+class ExecutionsStore {
+  private executions = new Map<string, ExecutionRecord>();
+  private listeners = new Map<string, Set<ExecutionListener>>();
+
+  create(sessionId: string, cell: CodeCellType) {
+    const id = randomid();
+    const record: ExecutionRecord = {
+      id,
+      sessionId,
+      cellId: cell.id,
+      status: 'running',
+      startedAt: Date.now(),
+      outputs: [],
+    };
+    this.executions.set(id, record);
+    return record;
+  }
+
+  get(execId: string) {
+    return this.executions.get(execId);
+  }
+
+  appendOutput(execId: string, output: ExecutionOutput) {
+    const rec = this.executions.get(execId);
+    if (!rec) return;
+    rec.outputs.push(output);
+    this.emit(execId, { type: 'output', data: output });
+  }
+
+  complete(execId: string, exitCode: number | null) {
+    const rec = this.executions.get(execId);
+    if (!rec) return;
+    rec.status = exitCode === 0 ? 'complete' : 'failed';
+    rec.exitCode = exitCode;
+    rec.completedAt = Date.now();
+    this.emit(execId, { type: 'status', data: { status: rec.status, exitCode } });
+  }
+
+  subscribe(execId: string, listener: ExecutionListener) {
+    if (!this.listeners.has(execId)) {
+      this.listeners.set(execId, new Set());
+    }
+    this.listeners.get(execId)!.add(listener);
+    return () => this.listeners.get(execId)!.delete(listener);
+  }
+
+  private emit(execId: string, evt: { type: 'output' | 'status'; data: any }) {
+    const subs = this.listeners.get(execId);
+    if (!subs) return;
+    for (const l of subs) l(evt);
+  }
+}
+
+const executions = new ExecutionsStore();
+
+export default executions;

--- a/packages/api/test/rest-exec.test.mts
+++ b/packages/api/test/rest-exec.test.mts
@@ -1,0 +1,74 @@
+import http from 'node:http';
+import { WebSocketServer } from 'ws';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import app from '../server/http.mjs';
+import wssHandler from '../server/ws.mjs';
+import { createSrcbook } from '../srcbook/index.mjs';
+import { createSession, addCell } from '../session.mjs';
+import { randomid } from '@srcbook/shared';
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = http.createServer(app);
+  const wss = new WebSocketServer({ server });
+  wss.on('connection', wssHandler.onConnection);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  const port = typeof address === 'string' ? 80 : (address?.port as number);
+  baseUrl = `http://127.0.0.1:${port}/api`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('REST execution API', () => {
+  it('executes a cell and streams outputs via polling', async () => {
+    const dir = await createSrcbook('Test', 'javascript');
+    const session = await createSession(dir);
+
+    const codeCell = {
+      id: randomid(),
+      type: 'code' as const,
+      source: "console.log('hello from rest')\n",
+      language: 'javascript' as const,
+      filename: 'index.js',
+      status: 'idle' as const,
+    };
+
+    // insert after title and package.json cells
+    await addCell(session, codeCell, 2);
+
+    const execResp = await fetch(`${baseUrl}/sessions/${session.id}/cells/${codeCell.id}/exec`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(execResp.ok).toBe(true);
+    const execJson = await execResp.json();
+    const execId = execJson.result.execId as string;
+    expect(typeof execId).toBe('string');
+
+    // Poll until complete
+    let done = false;
+    let outputs: Array<{ type: string; data: string }> = [];
+    let tries = 0;
+    while (!done && tries++ < 80) {
+      const poll = await fetch(`${baseUrl}/executions/${execId}`);
+      const body = await poll.json();
+      const rec = body.result as { status: string; outputs: Array<{ type: string; data: string }> };
+      outputs = rec.outputs;
+      if (rec.status === 'complete' || rec.status === 'failed') {
+        done = true;
+      } else {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    }
+
+    expect(done).toBe(true);
+    expect(outputs.map((o) => o.data).join('')).toContain('hello from rest');
+  }, 30000);
+});


### PR DESCRIPTION
Expose a REST API for cell execution and output streaming to allow headless clients to execute cells without implementing the WebSocket protocol.

---
<a href="https://cursor.com/background-agent?bcId=bc-de3f37a8-ab74-4db6-b8e8-641d5c75d20c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de3f37a8-ab74-4db6-b8e8-641d5c75d20c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

