### PR TITLE
Parameterize storage directories via environment variables

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -26,3 +26,18 @@ Currently, Srcbook runs all code inside of a Node.js process. Since your code is
 That said, we believe the ability to rapidly iterate on both FE and BE code is immensely valuable. We are in the early stages of designing feature(s) that allow you to write custom FE components in Srcbook that can also interact with the backend Node.js processes. This will unlock the ability to build entire applications inside Srcbook.
 
 If you are opinionated here or otherwise interested in contributing, please file an issue, open a discussion, or submit a PR. We love community involvement!
+
+### How do I change where Srcbook stores sessions and apps?
+
+By default, Srcbook stores data under `~/.srcbook`. You can override this by setting the `SRCBOOK_HOME` environment variable. When set, Srcbook will store data under `$SRCBOOK_HOME/.srcbook`, including `srcbooks/` and `apps/`.
+
+Examples:
+
+```bash
+# Use a workspace directory
+SRCBOOK_HOME=/workspace srcbook start
+
+# With Docker
+# Mount a host directory and point SRCBOOK_HOME to it
+docker run -p 2150:2150 -e SRCBOOK_HOME=/workspace -v /host/workspace:/workspace srcbook
+```

--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ docker run -p 2150:2150 -v ~/.srcbook:/root/.srcbook -v ~/.npm:/root/.npm srcboo
 
 Make sure to set up your API key after starting the container. You can do this through the web interface at `http://localhost:2150`.
 
+### Storage location
+
+By default, Srcbook stores data in `~/.srcbook` under your home directory. You can override the base directory by setting the `SRCBOOK_HOME` environment variable. When set, storage paths are resolved under `$SRCBOOK_HOME/.srcbook`.
+
+Examples:
+
+```bash
+# Store data under /workspace instead of the OS home directory
+SRCBOOK_HOME=/workspace srcbook start
+
+# With pnpm dlx
+SRCBOOK_HOME=/workspace pnpm dlx srcbook@latest start
+
+# In Docker
+# Mount a workspace directory and point SRCBOOK_HOME to it
+docker run -p 2150:2150 -e SRCBOOK_HOME=/workspace -v /host/workspace:/workspace srcbook
+```
+
 ### Current Commands
 
 ```bash

--- a/packages/api/config.mts
+++ b/packages/api/config.mts
@@ -10,7 +10,7 @@ import {
   apps,
 } from './db/schema.mjs';
 import { db } from './db/index.mjs';
-import { HOME_DIR } from './constants.mjs';
+import { STORAGE_HOME_DIR as HOME_DIR } from './constants.mjs';
 
 async function init() {
   const existingConfig = await db.select().from(configs).limit(1);

--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -9,7 +9,11 @@ const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
 
 export const HOME_DIR = os.homedir();
-export const SRCBOOK_DIR = path.join(HOME_DIR, '.srcbook');
+// If set, SRCBOOK_HOME overrides the default home directory when computing storage paths
+export const STORAGE_HOME_DIR = process.env.SRCBOOK_HOME && process.env.SRCBOOK_HOME.trim().length > 0
+  ? process.env.SRCBOOK_HOME
+  : HOME_DIR;
+export const SRCBOOK_DIR = path.join(STORAGE_HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');
 export const APPS_DIR = path.join(SRCBOOK_DIR, 'apps');
 export const DIST_DIR = _dirname;

--- a/packages/api/constants.mts
+++ b/packages/api/constants.mts
@@ -11,7 +11,7 @@ const _dirname = path.dirname(_filename);
 export const HOME_DIR = os.homedir();
 // If set, SRCBOOK_HOME overrides the default home directory when computing storage paths
 export const STORAGE_HOME_DIR = process.env.SRCBOOK_HOME && process.env.SRCBOOK_HOME.trim().length > 0
-  ? process.env.SRCBOOK_HOME
+  ? process.env.SRCBOOK_HOME.trim()
   : HOME_DIR;
 export const SRCBOOK_DIR = path.join(STORAGE_HOME_DIR, '.srcbook');
 export const SRCBOOKS_DIR = path.join(SRCBOOK_DIR, 'srcbooks');

--- a/packages/api/db/index.mts
+++ b/packages/api/db/index.mts
@@ -3,14 +3,14 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
 import * as schema from './schema.mjs';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { HOME_DIR, DIST_DIR, SRCBOOKS_DIR } from '../constants.mjs';
+import { DIST_DIR, SRCBOOKS_DIR, SRCBOOK_DIR } from '../constants.mjs';
 import fs from 'node:fs';
 
 // We can't use a relative directory for drizzle since this application
 // can get run from anywhere, so use DIST_DIR as ground truth.
 const drizzleFolder = path.join(DIST_DIR, 'drizzle');
 
-const DB_PATH = `${HOME_DIR}/.srcbook/srcbook.db`;
+const DB_PATH = path.join(SRCBOOK_DIR, 'srcbook.db');
 
 // Creates the HOME/.srcbook/srcbooks dir
 fs.mkdirSync(SRCBOOKS_DIR, { recursive: true });

--- a/packages/api/server/http.mts
+++ b/packages/api/server/http.mts
@@ -80,8 +80,11 @@ router.post('/file', cors(), async (req, res) => {
 
   try {
     const content = await fs.readFile(file, 'utf8');
-    const cell = file.includes('.srcbook/srcbooks') && !file.includes('node_modules');
-    const filename = cell ? file.split('/').pop() || file : file;
+    const normalizedFile = Path.resolve(file);
+    const relToSrcbooks = Path.relative(SRCBOOKS_DIR, normalizedFile);
+    const isInSrcbooksDir = !relToSrcbooks.startsWith('..') && !Path.isAbsolute(relToSrcbooks);
+    const cell = isInSrcbooksDir && !normalizedFile.includes(`${Path.sep}node_modules${Path.sep}`);
+    const filename = cell ? normalizedFile.split(Path.sep).pop() || normalizedFile : normalizedFile;
 
     return res.json({
       error: false,


### PR DESCRIPTION
Parameterize storage directories via `SRCBOOK_HOME` environment variable to allow configurable data locations.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7be86f8-be03-42f1-926d-208699bf8d97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7be86f8-be03-42f1-926d-208699bf8d97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

